### PR TITLE
Major update of ERC-3525 protocol (#5186)

### DIFF
--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -1,8 +1,8 @@
 ---
 eip: 3525
 title: Semi-Fungible Token Standard
-author: Will Wang (@will-edge), Mike Meng <myan@solv.finance>, TsaiYee <yee.tsai@gmail.com>, Ryan Chow <ryanchow@solv.finance>, Zhongxin Wu <wuzhongxin@solv.finance>, AlvisDu <dujincai@solv.finance>
-discussions-to: https://github.com/ethereum/EIPs/issues/3641
+author: Will Wang (@will-edge), Mike Meng <myan@solv.finance>, Ethan Y. Tsai <yee.tsai@gmail.com>, Ryan Chow <ryanchow@solv.finance>, Zhongxin Wu <wuzhongxin@solv.finance>, AlvisDu <alvis@solv.finance>
+discussions-to: https://ethereum-magicians.org/t/erc-3525-the-semi-fungible-token-standard
 status: Draft
 type: Standards Track
 category: ERC
@@ -10,328 +10,423 @@ created: 2020-12-01
 requires: 165, 721
 ---
 
+Table of Contents
+- [Simple Summary](#simple-summary)
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Specification](#specification)
+- [Rationale](#rationale)
+- [Backwards Compatibility](#backwards-compatibility)
+- [Implementations](#implementations)
+- [Copyright](#copyright)
+
 ## Simple Summary
 
-This is a standard for semi-fungible tokens. The set of smart contract interfaces described in this document defines an ERC-721 extension, by introducing an <ID, SLOT, AMOUNT> triple scalar model to represent the semi-fungible nature of a token. This standard also introduces an optional set of interfaces called 'UnderlyingContainer', for an ERC-3525 token to act as a representing layer of existing tokens, which is one of the key purpose of tokenization.
+This is a standard for semi-fungible tokens. The set of smart contract interfaces described in this document defines an ERC-721 extension/compatible token standard. This standard introduces an <ID, SLOT, VALUE> triple scalar model that represents the semi-fungible structure of a token. It also introduces new transfer models as well as approval models that reflect the semi-fungible nature of the tokens.
 
 ## Abstract
 
-ERC-3525 is ERC-721 compatible, which means, as an ERC-721 token, each ERC-3525 token contains an ID property to identify itself as a universally unique entity. What empowers a ERC-3525 token is that it contains a 'units' property, representing the quantitative nature of the token. Thus, a ERC-3525 token can be split into several different ERC-3525 tokens, with certain properties maintained unchanged but the sum of the units of all split-out token equals that of the original one. Nevertheless, each ERC-3525 token has a 'SLOT' attribute, which labels its logical category. Several ERC-3525 tokens can be merged into one if their SLOT attributes indicate that they are of the same category.
+ERC-3525 is an ERC-721 compatible token standard, where each ERC-3525 token, like an ERC-721 token, contains an ID property to identify itself as a universally unique entity, so that the tokens can be transferred between addresses and approved to be operated in ERC-721 compatible way.
+
+ERC-3525 tokens also contain a 'value' property, representing the quantitative nature of the token. The meaning of the 'value' property is quite like that of the 'balance' property of an ERC-20 token. Each ERC-3525 token has a 'slot' attribute, ensuring that the value of two ERC-3525 tokens with the same slot be treated as fungible, adding fungibility to the value property of the tokens.
+
+ERC-3525 introduces new token transfer models for semi-fungibility,  including value transfer between two tokens of the same slot and value transfer from a token to an address.
 
 ## Motivation
 
-Tokenization of assets is one of the most important applications in crypto. Normally there are two options when tokenizing assets: fungible and non-fungible. The first one generally uses the ERC-20 standard, in the case that every unit of assets is identical to each other, ERC-20 standard provides a flexible and efficient way to manipulate fungible tokens. The second one predominately uses the ERC-721 token standard, for that each asset needs to be described by one or more customized properties. For example, when a decentralized exchange that supports the Automatic Market-Making model allows its liquidity providers to specify their positions at different price ranges, an LP token can be implemented in ERC-721, since this token standard has the capability to identify each position as an entity, with different attributes for each entity.
+Tokenization is one of the most important trends by which to use and control digital assets in crypto. Traditionally, there are two approaches to do so: fungible and non-fungible tokens. Fungible tokens are generally powered by ERC-20 standard, where every unit of an asset is identical to each other. ERC-20 is a flexible and efficient way to manipulate fungible tokens. Non-fungible tokens are predominantly ERC-721 tokens, powered by a standard capable of distinguishing digital assets from one another based on identity. 
 
-Both options have significant drawbacks. In the fungible way, one needs to create a separate ERC-20 contract for each different value or combination of customizable properties, which can easily require an unacceptable number of ERC-20 contracts in practice. On the other hand, there is no quantitative feature in an ERC-721, hence significantly reducing the computability, liquidity, and manageability. For example, when we want to stake part of the position LP in some smart contract, the liquidity has to be withdrawn from the LP to create a new one, causes inconvenience and temporary decrease of liquidity.
+However, both have significant drawbacks. For example, ERC-20 requires that users create a separate ERC-20 contract for each individual data structure or combination of customizable properties, resulting in an unrealistic amount of ERC-20 contracts that need to be created in practice. On the other hand, ERC-721 tokens provide no quantitative feature, hence significantly undercutting their computability, liquidity, and manageability. For example, if we are to create financial instruments such as bonds, insurance policy, vesting plans using ERC-721, no standard interfaces are available for us to control the value in them, making it impossible, for example, to transfer a portion of the equity in the contract represented by the token. 
 
-An intuitive and direct way to solve the problem is to add a property to represent the quantitative nature directly to an ERC-721 token, making it best for both property customization and semi-fungibility. Furthermore, the ERC-721 compatibility would help the new standard easily utilize existing infrastructures and gain fast adoption.
+A more intuitive and straightforward way to solve the problem is to create a semi-fungible token that has the quantitative features of ERC-20 and qualitative attributes of ERC-721. The backwards-compatibility of such semi-fungible tokens would help utilize existing infrastructures already in use and lead to faster adoption.
 
-For further design motivations, see papers and documents below:
+For further design motivations, please view papers and documents below:
 
 **Articles & Discussions**
 
-- [How vnft can improve position management in uniswap-v3](https://solvprotocol.medium.com/how-vnft-can-improve-position-management-in-uniswap-v3-221ab49a8cb2)
+- [How ERC-3525 can improve position management in uniswap-v3](https://solvprotocol.medium.com/how-vnft-can-improve-position-management-in-uniswap-v3-221ab49a8cb2)
 - [What are digital assets](https://unizon.pro/en/7632.html)
-- [Vnft tokens vs.erc-20 vs. erc-721](https://medium.com/solv-blog/vnft-tokens-vs-erc-20-vs-erc-721-e75843053786)
-
+- [ERC-3525 tokens vs.erc-20 vs. erc-721](https://medium.com/solv-blog/vnft-tokens-vs-erc-20-vs-erc-721-e75843053786)
 
 ## Specification
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
-
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
 **Related Standards**
+
 - [ERC-721 Non-Fungible Token Standard](./eip-721.md)
 - [ERC-165 Standard Interface Detection](./eip-165.md)
 - [JSON Schema](https://json-schema.org/)
 - [RFC 2119 Key words for use in RFCs to Indicate Requirement Levels](https://www.ietf.org/rfc/rfc2119.txt)
 
-
-
 **Every ERC-3525 compliant contract must implement the ERC3525, ERC721 and ERC165 interfaces**
 
+
 ```solidity
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 
 /**
  * @title ERC-3525 Semi-Fungible Token Standard
  * @dev See https://eips.ethereum.org/EIPS/eip-3525
- * Note: the ERC-165 identifier for this interface is 0x1487d183.
+ * Note: the ERC-165 identifier for this interface is 0xc97ae3d5.
  */
-interface IERC3525 /* is ERC-721 */{
+interface IERC3525 /* is IERC165, IERC721 */ {
+    /**
+     * @dev MUST emit when value of a token is transferred to another token with the same slot,
+     *  including zero value transfers (_value == 0) as well as transfers when tokens are created
+     *  (`_fromTokenId` == 0) or destroyed (`_toTokenId` == 0).
+     * @param _fromTokenId The token id to transfer value from
+     * @param _toTokenId The token id to transfer value to
+     * @param _value The transferred value
+     */
+    event TransferValue(uint256 indexed _fromTokenId, uint256 indexed _toTokenId, uint256 _value);
 
     /**
-     * @dev This emits when partial units of a token are transferred to another.
-     * @param _from The address of the owner of `_tokenId`
-     * @param _to The address of the owner of `_targetTokenId`
-     * @param _tokenId The token to partially transfer
-     * @param _targetTokenId The token to receive the units transferred
-     @ @param _transferUnits The amount of units to transfer
-     */
-    event TransferUnits(address indexed _from, address indexed _to, uint256 indexed _tokenId, uint256 _targetTokenId, uint256 _transferUnits);
-
-    /**
-     * @dev This emits when a token is split into two.
-     * @param _owner The address of the owner of both `_tokenId` and `_newTokenId`
-     * @param _tokenId The token to be split
-     * @param _newTokenId The new token created after split
-     @ @param _splitUnits The amount of units to be split from `_tokenId` to `_newTokenId`
-     */
-    event Split(address indexed _owner, uint256 indexed _tokenId, uint256 _newTokenId, uint256 _splitUnits);
-    
-    /**
-     * @dev This emits when a token is merged into another.
-     * @param _owner The address of the owner of both `_tokenId` and `_targetTokenId`
-     * @param _tokenId The token to be merged into `_targetTokenId`
-     * @param _targetTokenId The token to receive all units of `_tokenId`
-     @ @param _mergeUnits The amount of units to be merged from `_tokenId` to `_targetTokenId`
-     */
-    event Merge(address indexed _owner, uint256 indexed _tokenId, uint256 indexed _targetTokenId, uint256 _mergeUnits);
-    
-    /**
-     * @dev This emits when the approved units of the approved address for a token is set or changed.
-     * @param _owner The address of the owner of the token
-     * @param _approved The address of the approved operator
+     * @dev MUST emit when the approval value of a token is set or changed.
      * @param _tokenId The token to approve
-     @ @param _approvalUnits The amount of approved units for the operator
+     * @param _operator The operator to approve for
+     * @param _value The maximum value that `_operator` is allowed to manage
      */
-    event ApprovalUnits(address indexed _owner, address indexed _approved, uint256 indexed _tokenId, uint256 _approvalUnits);
+    event ApprovalValue(uint256 indexed _tokenId, address indexed _operator, uint256 _value);
+    
+    /**
+     * @dev MUST emit when the slot of a token is set or changed.
+     * @param _tokenId The token of which slot is set or changed
+     * @param _oldSlot The previous slot of the token
+     * @param _newSlot The updated slot of the token
+     */ 
+    event SlotChanged(uint256 indexed _tokenId, uint256 indexed _oldSlot, uint256 indexed _newSlot);
 
     /**
-     * @dev Find the slot of a token.
+     * @notice Get the number of decimals the token uses for value - e.g. 6, means the user
+     *  representation of the value of a token can be calculated by dividing it by 1,000,000.
+     *  Considering the compatibility with third-party wallets, this function is defined as
+     *  `valueDecimals()` instead of `decimals()` to avoid conflict with ERC20 tokens.
+     * @return The number of decimals for value
+     */
+    function valueDecimals() external view returns (uint8);
+
+    /**
+     * @notice Get the value of a token.
+     * @param _tokenId The token for which to query the balance
+     * @return The value of `_tokenId`
+     */
+    function balanceOf(uint256 _tokenId) external view returns (uint256);
+
+    /**
+     * @notice Get the slot of a token.
      * @param _tokenId The identifier for a token
      * @return The slot of the token
      */
-    function slotOf(uint256 _tokenId)  external view returns(uint256);
+    function slotOf(uint256 _tokenId) external view returns (uint256);
 
     /**
-     * @dev Count all tokens holding the same slot.
-     * @param _slot The slot of which to count tokens
-     * @return The number of tokens of the specified slot
-     */
-    function supplyOfSlot(uint256 _slot) external view returns (uint256);
-
-    /**
-     * @dev Find the number of decimals a token uses for units - e.g. 6, means the user representation of the units of a token can be calculated by dividing it by 1,000,000.
-     * @return The number of decimals for units of a token
-     */
-    function unitDecimals() external view return (uint8);
-    /**
-     * @dev Enumerate all tokens of a slot.
-     * @param _slot The slot of which to enumerate tokens
-     * @param _index The index in the token list of the slot
-     * @return The id for the `_index`th token in the token list of the slot
-     */
-    function tokenOfSlotByIndex(uint256 _slot, uint256 _index) external view returns (uint256);
-
-    /**
-     * @dev Find the amount of units of a token.
-     * @param _tokenId The token to query units
-     * @return The amount of units of `_tokenId`
-     */
-    function unitsInToken(uint256 _tokenId) external view returns (uint256);
-
-    /**
-     * @dev Set or change the approved units of an operator for a token.
-     * @param _to The address of the operator to be approved
+     * @notice Allow an operator to manage the value of a token, up to the `_value`.
+     * @dev MUST revert unless caller is the current owner, an authorized operator, or the approved
+     *  address for `_tokenId`.
+     *  MUST emit the ApprovalValue event.
      * @param _tokenId The token to approve
-     * @param _units The amount of approved units for the operator
+     * @param _operator The operator to be approved
+     * @param _value The maximum value of `_toTokenId` that `_operator` is allowed to manage
      */
-    function approve(address _to, uint256 _tokenId, uint256 _units) external;
+    function approve(
+        uint256 _tokenId,
+        address _operator,
+        uint256 _value
+    ) external payable;
 
     /**
-     * @dev Find the approved units of an operator for a token.
-     * @param _tokenId The token to find the operator for
-     * @param _spender The address of an operator
-     * @return The approved units of `_spender` for `_tokenId`
+     * @notice Get the maximum value of a token that an operator is allowed to manage.
+     * @param _tokenId The token for which to query the allowance
+     * @param _operator The address of an operator
+     * @return The current approval value of `_tokenId` that `_operator` is allowed to manage
      */
-    function allowance(uint256 _tokenId, address _spender) external view returns (uint256);
+    function allowance(uint256 _tokenId, address _operator) external view returns (uint256);
 
     /**
-     * @dev Split a token into several by separating its units and assigning each portion to a new created token.
-     * @param _tokenId The token to split
-     * @param _units The amounts to split, i.e., the units of the new tokens created after split
-     * @return The ids of the new tokens created after split
+     * @notice Transfer value from a specified token to another specified token with the same slot.
+     * @dev Caller MUST be the current owner, an authorized operator or an operator who has been
+     *  approved the whole `_fromTokenId` or part of it.
+     *  MUST revert if `_fromTokenId` or `_toTokenId` is zero token id or does not exist.
+     *  MUST revert if slots of `_fromTokenId` and `_toTokenId` do not match.
+     *  MUST revert if `_value` exceeds the balance of `_fromTokenId` or its allowance to the
+     *  operator.
+     *  MUST emit `TransferValue` event.
+     * @param _fromTokenId The token to transfer value from
+     * @param _toTokenId The token to transfer value to
+     * @param _value The transferred value
      */
-    function split(uint256 _tokenId, uint256[] calldata _units) external returns (uint256[] memory);
+    function transferFrom(
+        uint256 _fromTokenId,
+        uint256 _toTokenId,
+        uint256 _value
+    ) external payable;
 
     /**
-     * @dev Merge several tokens into one by merging their units into a target token before burning them.
-     * @param _tokenIds The tokens to merge
-     * @param _targetTokenId The token to receive all units of the merged tokens
+     * @notice Transfer value from a token to another token with the same slot.
+     * @dev This function MUST check if the recipient address is a smart contract. If so, it MUST
+     *  call `onERC3525Received` on the recipient contract and verify the return value.
+     *  MUST revert if `_fromTokenId` or `_toTokenId` is zero token id or does not exist.
+     *  MUST revert if slots of `_fromTokenId` and `_toTokenId` do not match.
+     *  MUST revert if `_value` exceeds the balance of `_fromTokenId` or its allowance to the
+     *  operator.
+     *  MUST revert if the recipient contract rejects the transfer.
+     *  MUST emit `TransferValue` event.
+     * @param _fromTokenId The token to transfer value from
+     * @param _toTokenId The token to transfer value to
+     * @param _value The transferred value
+     * @param _data Additional data with no specified format
      */
-    function merge(uint256[] calldata _tokenIds, uint256 _targetTokenId) external;
+    function safeTransferFrom(
+        uint256 _fromTokenId,
+        uint256 _toTokenId,
+        uint256 _value,
+        bytes calldata _data
+    ) external payable;
 
     /**
-     * @dev Transfer units from a token to a newly created token. When transferring to a smart contract, the caller SHOULD check if the recipient is capable of receiving ERC-3525 token units.
-     * @param _from The address of the owner of the token to transfer
-     * @param _to The address of the owner the newly created token
-     * @param _tokenId The token to partially transfer
-     * @param _units The amount of units to transfer
-     * @return The token created after transfer containing the transferred units
+     * @notice Transfer value from a specified token to an address. The caller should confirm that
+     *  `_to` is capable of receiving ERC3525 tokens.
+     * @dev This function MUST create a new ERC3525 token with the same slot for `_to` to receive
+     *  the transferred value.
+     *  MUST revert if `_fromTokenId` is zero token id or does not exist.
+     *  MUST revert if `_to` is zero address.
+     *  MUST revert if `_value` exceeds the balance of `_fromTokenId` or its allowance to the
+     *  operator.
+     *  MUST emit `Transfer` and `TransferValue` events.
+     * @param _fromTokenId The token to transfer value from
+     * @param _to The address to transfer value to
+     * @param _value The transferred value
+     * @return ID of the token which receives the transferred value
      */
-    function transferFrom(address _from, address _to, uint256 _tokenId, uint256 _units) external returns (uint256);
+    function transferFrom(
+        uint256 _fromTokenId,
+        address _to,
+        uint256 _value
+    ) external payable returns (uint256);
 
     /**
-     * @dev Transfer partial units of a token to a newly created token. If `_to` is a smart contract, this function MUST call `onERC3525Received` on `_to` after transferring and then verify the return value.
-     * @param _from The address of the owner of the token to transfer
-     * @param _to The address of the owner the newly created token
-     * @param _tokenId The token to partially transfer
-     * @param _units The amount of units to transfer
-     * @param _data
-     * @return The token created after transfer containing the transferred units
+     * @notice Transfer value from a specified token to an address.
+     * @dev This function MUST create a new ERC3525 token with the same slot for `_to` to receive
+     *  the transferred value.
+     *  This function MUST check if the recipient address is a smart contract. If so, it MUST call
+     *  `onERC721Received` on the recipient contract and verify the return value.
+     *  MUST revert if `_fromTokenId` is zero token id or does not exist.
+     *  MUST revert if `_to` is zero address.
+     *  MUST revert if `_value` exceeds the balance of `_fromTokenId` or its allowance to the
+     *  operator.
+     *  MUST revert if the recipient contract rejects the transfer.
+     *  MUST emit `Transfer` and `TransferValue` events.
+     * @param _fromTokenId The token to transfer value from
+     * @param _to The address to transfer value to
+     * @param _value The transferred value
+     * @param _data Additional data with no specified format
+     * @return ID of the token which receives the transferred value
      */
-    function safeTransferFrom(address _from, address _to, uint256 _tokenId, uint256 _units, bytes calldata _data) external returns (uint256);
-
-    /**
-     * @dev Transfer units from a token to another token. When transferring to a smart contract, the caller SHOULD check if the recipient is capable of receiving ERC-3525 token units.
-     * @param _from The address of the owner of the token to transfer
-     * @param _to The address of the owner the token to receive units
-     * @param _tokenId The token to transfer units from
-     * @param _targetTokenId The token to receive units
-     * @param _units The amount of units to transfer
-     */
-    function transferFrom(address _from, address _to, uint256 _tokenId, uint256 _targetTokenId, uint256 _units) external;
-
-    /**
-     * @dev Transfer partial units of a token to an existing token. If `_to` is a smart contract, this function MUST call `onERC3525Received` on `_to` after transferring and then verify the return value.
-     * @param _from The address of the owner of the token to transfer
-     * @param _to The address of the owner the token to receive units
-     * @param _tokenId The token to partially transfer
-     * @param _targetTokenId The token to receive units
-     * @param _units The amount of units to transfer
-     * @param _data
-     */
-    function safeTransferFrom(address _from, address _to, uint256 _tokenId, uint256 _targetTokenId, uint256 _units, bytes calldata _data) external;
+    function safeTransferFrom(
+        uint256 _fromTokenId,
+        address _to,
+        uint256 _value,
+        bytes calldata _data
+    ) external payable returns (uint256);
 }
 ```
+
+The slot's enumeration extension is OPTIONAL for ERC-3525 smart contracts. This allows your contract to publish its full list of SLOT and make them discoverable.
+
+```solidity
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC-3525 Semi-Fungible Token Standard, optional extension for slot enumeration
+ * @dev Interfaces for any contract that wants to support enumeration of slots as well as tokens 
+ *  with the same slot.
+ *  See https://eips.ethereum.org/EIPS/eip-3525
+ * Note: the ERC-165 identifier for this interface is 0x3b741b9e.
+ */
+interface IERC3525SlotEnumerable is IERC3525 /* , IERC721Enumerable */ {
+
+    /**
+     * @notice Get the total amount of slots stored by the contract.
+     * @return The total amount of slots
+     */
+    function slotCount() external view returns (uint256);
+
+    /**
+     * @notice Get the slot at the specified index of all slots stored by the contract.
+     * @param _index The index in the slot list
+     * @return The slot at `index` of all slots.
+     */
+    function slotByIndex(uint256 _index) external view returns (uint256);
+
+    /**
+     * @notice Get the total amount of tokens with the same slot.
+     * @param _slot The slot to query token supply for
+     * @return The total amount of tokens with the specified `_slot`
+     */
+    function tokenSupplyInSlot(uint256 _slot) external view returns (uint256);
+
+    /**
+     * @notice Get the token at the specified index of all tokens with the same slot.
+     * @param _slot The slot to query tokens with
+     * @param _index The index in the token list of the slot
+     * @return The token ID at `_index` of all tokens with `_slot`
+     */
+    function tokenInSlotByIndex(uint256 _slot, uint256 _index) external view returns (uint256);
+}
+```
+
+The slot level approval is OPTIONAL for ERC-3525 smart contracts. This allows any contract that wants to support approval for slots, which allows an operator to manage one's tokens with the same slot.
+```solidity
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC-3525 Semi-Fungible Token Standard, optional extension for approval of slot level
+ * @dev Interfaces for any contract that wants to support approval of slot level, which allows an
+ *  operator to manage one's tokens with the same slot.
+ *  See https://eips.ethereum.org/EIPS/eip-3525
+ * Note: the ERC-165 identifier for this interface is 0xb688be58.
+ */
+interface IERC3525SlotApprovable is IERC3525 {
+    /**
+     * @dev MUST emit when an operator is approved or disapproved to manage all of `_owner`'s
+     *  tokens with the same slot.
+     * @param _owner The address whose tokens are approved
+     * @param _slot The slot to approve, all of `_owner`'s tokens with this slot are approved
+     * @param _operator The operator being approved or disapproved
+     * @param _approved Identify if `_operator` is approved or disapproved
+     */
+    event ApprovalForSlot(address indexed _owner, uint256 indexed _slot, address indexed _operator, bool _approved);
+
+    /**
+     * @notice Approve or disapprove an operator to manage all of `_owner`'s tokens with the
+     *  specified slot.
+     * @dev Caller SHOULD be `_owner` or an operator who has been authorized through
+     *  `setApprovalForAll`.
+     *  MUST emit ApprovalSlot event.
+     * @param _owner The address that owns the ERC3525 tokens
+     * @param _slot The slot of tokens being queried approval of
+     * @param _operator The address for whom to query approval
+     * @param _approved Identify if `_operator` would be approved or disapproved
+     */
+    function setApprovalForSlot(
+        address _owner,
+        uint256 _slot,
+        address _operator,
+        bool _approved
+    ) external payable;
+
+    /**
+     * @notice Query if `_operator` is authorized to manage all of `_owner`'s tokens with the
+     *  specified slot.
+     * @param _owner The address that owns the ERC3525 tokens
+     * @param _slot The slot of tokens being queried approval of
+     * @param _operator The address for whom to query approval
+     * @return True if `_operator` is authorized to manage all of `_owner`'s tokens with `_slot`,
+     *  false otherwise.
+     */
+    function isApprovedForSlot(
+        address _owner,
+        uint256 _slot,
+        address _operator
+    ) external view returns (bool);
+}
+```
+
 
 ### ERC-3525 Token Receiver
 
-Smart contracts MUST implement all of the functions in the IERC3525Receiver interface to accept transfers. See “Safe Transfer Rules” for further detail. 
+Smart contracts MUST implement all of the functions in the IERC3525Receiver interface to accept transfers. See "Safe Transfer Rules" for further detail.
 
-```javascript
- /**
-        @notice Handle the receipt of a ERC-3525 token type.
-        @dev A ERC-3525 compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeTransferFrom` after the balance has been updated.        
-        This function MUST return `bytes4(keccak256("onERC3525Received(address,address,uint256,uint256,bytes)"))` (i.e. 0xb382cdcd) if it accepts the transfer.
-        This function MUST revert if it rejects the transfer.
-        Return of any other value than the prescribed keccak256 generated value MUST result in the transaction being reverted by the caller.
-        @param operator  The address which initiated the transfer (i.e. msg.sender)
-        @param from      The address which previously owned the token
-        @param id        The ID of the token being transferred
-        @param units     The units of tokenId being transferred
-        @param data      Additional data with no specified format
-        @return           `bytes4(keccak256("onERC3525Received(address,address,uint256,uint256,bytes)"))`
-	Note: the ERC-165 identifier for this interface is 0xb382cdcd.
+```solidity
+ pragma solidity ^0.8.0;
+
+/**
+ * @title ERC3525 token receiver interface
+ * @dev Interface for any contract that wants to support safeTransfers from ERC3525 contracts.
+ * Note: the ERC-165 identifier for this interface is 0x009ce20b.
  */
 interface IERC3525Receiver {
-    function onERC3525Received(address operator, address from, uint256 tokenId,
-        uint256 units, bytes calldata data) external returns (bytes4);
+    /**
+     * @notice Handle the receipt of an ERC3525 token value.
+     * @dev An ERC3525 smart contract MUST call this function on the recipient contract after a 
+     *  value transfer (i.e. `safeTransferFrom(uint256,uint256,uint256,bytes)`).
+     *  MUST return 0x009ce20b (i.e. `bytes4(keccak256('onERC3525Received(address,uint256,uint256,
+     *  uint256,bytes)'))`) if the transfer is accepted.
+     *  MUST revert or return any value other than 0x009ce20b if the transfer is rejected.
+     * @param _operator The address which triggered the transfer
+     * @param _fromTokenId The token id to transfer value from
+     * @param _toTokenId The token id to transfer value to
+     * @param _value The transferred value
+     * @param _data Additional data with no specified format
+     * @return `bytes4(keccak256('onERC3525Received(address,uint256,uint256,uint256,bytes)'))` 
+     *  unless the transfer is rejected.
+     */
+    function onERC3525Received(address _operator, uint256 _fromTokenId, uint256 _toTokenId, uint256 _value, bytes calldata _data) external returns (bytes4);
+
 }
 ```
 
-
 ### Token Manipulation
-
 
 #### Scenarios
 
 **_Transfer:_**
-	
-An ERC-3525 token is ERC-721 compatible, it adds units transfer ability, that can transfer units from one token to another token.
 
-The units level transfer has two types of interfaces, and both have safe and unsafe versions:
+Besides ERC-721 compatible token transfer methods, ERC-3525 introduces two new transfer models: value transfer from ID to ID, and value transfer from ID to address.
 
 ```solidity
+1. function transferFrom(uint256 _fromTokenId, uint256 _toTokenId, uint256 _value) external payable;
+   function safeTransferFrom(uint256 _fromTokenId, uint256 _toTokenId, uint256 _value, bytes calldata _data) external payable;
 	
-1. function transferFrom(address from, address to, uint256 tokenId, uint256 targetTokenId, uint256 units) external; 
-   function safeTransferFrom(address from, address to, uint256 tokenId, uint256 targetTokenId, uint256 units, 
-	    bytes calldata data) external; 
-
-2. function transferFrom(address from, address to, uint256 tokenId, uint256 units) external returns (uint256 newTokenId);
-   function safeTransferFrom(address from, address to, uint256 tokenId, uint256 units, bytes calldata data) 
-	    external returns (uint256 newTokenId);
-
+2. function transferFrom(uint256 _fromTokenId, address _to, uint256 _value) external payable returns (uint256 toTokenId_);
+   function safeTransferFrom(uint256 _fromTokenId, address _to, uint256 _value, bytes calldata _data) external payable returns (uint256 toTokenId_);
 ```
-The main difference between the two kinds of interface is whether the application or the contract is responsible for determining/generating the target token ID in the transfer.
-
-Since transferring units of a token will possibly result in new token id creation, it's important to give the implementing contract the ability to do that. On the other hand, since part of a token can be transferred to a token with the same slot, we want to keep the flexibility for dapps to determine whether to use this ability, resulting in less contract complexity and less gas consumption.
 
 
-**_Merge:_**
+The first one allows value transfers from one token (specified by `_fromTokenId`) to another token (specified by `_toTokenId`) with the same slot, as a result, the `_value` will be subtracted from the value of the source token and added to the value of the destination token; 
 
-Several tokes with the same SLOT can be merged together using `merge(uint256[] calldata tokenIds, uint256 targetTokenId);`. `targetTokenId` should already exist, and cannot be one of `tokenIds`. After merging, `targetTokenId` owns all the units from the merged tokens, and the merged tokens will be burned.
-
-
-**_Split:_**
-
-One token can be split into several tokens, using`split(uint256 tokenId, uint256[] calldata units) returns (uint256[] memory newTokenIds);`. This will result in several newly generated tokens containing units equal to the parameter `units`.
-
+The second one allows value transfers from one token (specified by `_fromTokenId`) to an address (specified by `_to`), the value is actually transferred to a token owned by the address, and the id of the destination token should be returned. Further explanation can be found in the 'design decision' section for this method.
 
 
 #### Rules
 
 **_approving rules:_**
 
-- For being compatible with ERC721, there are three kinds of approving operations, which SHOULD be used to indicate different levels of approval.
-- `setApprovalForAll` SHOULD indicate the top level of approval, the authorized operators are capable of handling all tokens, including their units, owned by the owner.
-- The ID level `approve` SHOULD indicate that the `_tokenId` is approved to the operator, but not the units of that token.
-- The units level `approve` with the `_units` parameter SHOULD indicate that only the specified amount of units are approved to the operator, but not the whole token.
-- Any `approve` MUST revert if `msg.sender` is equal to `_to` or `_operator`.
-- The units level `approve` MUST revert if `msg.sender` is not the owner of `_tokenId` nor set approval for all tokens.
-- The units level `approve` MUST emit the `ApprovalUnits` event.
+ERC-3525 provides four kinds of approving functions indicating different levels of approvals, which can be described as full level approval, slot level approval, token ID level approval as well as value level approval.
 
-**_splitting rules:_**
-
-- MUST revert if `_tokenId` is not a valid token.
-- MUST revert if `msg.sender` is neither the owner of `_tokenId` nor set approval for all.
-- MUST revert if the sum of all `_units` exceeds the actual amount of units in `_tokenId`.
-- MUST return an array containing the ids of the generated tokens after splitting.
-- MUST emit the `Split` event.
-
-**_merging rules:_**
-
-- MUST revert if `_targetTokenId` or any of `_tokenIds` is not a valid token.
-- MUST revert if the owner of `tokenId` is not the owner of `_targetTokenId`.
-- MUST revert if `msg.sender` is neither the owner of all `_tokenIds` and `targetTokenId` nor having been set approval for all.
-- MUST revert if any of `_tokenIds` is equal to `_targetTokenId`.
-- Each of `_tokenIds` MUST be burnt after being merged.
-- MUST emit the `Merge` event.
+- `setApprovalForAll`, compatible with ERC721, SHOULD indicate the full level of approval, which means that the authorized operators are capable of managing all the tokens, including their values, owned by the owner.
+- `setApprovalForSlot` (optional) SHOULD indicate the slot level of approval, which means that the authorized operators are capable of managing all the tokens with the specified slot, including their values, owned by the owner.
+- The token ID level `approve` function, compatible with ERC721, SHOULD indicate that the authorized operator is capable of managing only the specified token ID, including its value, owned by the owner.
+- The value level `approve` function, SHOULD indicate that the authorized operator is capable of managing the specified maximum value of the specified token owned by the owner.
+- For any approving function, the caller MUST be the owner or has been approved with a higher level of authority.
 
 **_transferFrom rules:_**
 
-- The `transferFrom` without the `_targetTokenId` parameter SHOULD indicate transferring units to the recipient, whether the units are transferred into an existing token or a generated new token, should be decided by the implementation contract.
-	- MUST revert unless `msg.sender` is the owner of `_tokenId`, or having been set approval for all tokens, or having been approved for a certain number units of `_tokenId`.	
-	- MUST revert if `_tokenId` is not a valid token.
-	- MUST revert if `_from` is not the current owner of `_tokenId`.
-	- MUST revert if `_to` is the zero address.
-	- MUST revert if the transfer amount exceeds the actual amount of units in `_tokenId`.
-	- MUST revert if the transfer amount exceeds the approved units limit.
-	- MUST return the newly created token of the recipient containing the transferred units.
-	- MUST emit the `TransferUnits` event.
-	
-- The `transferFrom` with both the `_units` and the `_targetTokenId` parameters SHOULD indicate transferring units to an existing token of the recipient.
-	- MUST revert unless `msg.sender` is the owner of `_tokenId`, or having been set approval for all tokens, or the transfer amount is within the ERC-3525 approved units limit.
-	- MUST revert if either `_tokenId` or `_targetTokenId` is not a valid token.
-	- MUST revert if `_from` is not the current owner of `_tokenId`.
-	- MUST revert if `_to` is not the current owner of `_targetTokenId`.
-	- MUST revert if `_to` is the zero address.
-	- MUST revert if the transfer amount exceeds the actual amount of units in `_tokenId`.
-	- MUST revert if the transfer amount exceeds the ERC-3525 approved units limit.
-	- MUST emit the ERC-3525 level `TransferUnits` event.
+- The `transferFrom(uint256 _fromTokenId, uint256 _toTokenId, uint256 _value)` function, SHOULD indicate value transfers from one token to another token, in accordance with the rules below:
+
+  - MUST revert unless `msg.sender` is the owner of `_fromTokenId`, an authorized operator or an operator who has been approved the whole token or at least `_value` of it.
+  - MUST revert if `_fromTokenId` or `_toTokenId` is zero token id or does not exist.
+  - MUST revert if slots of `_fromTokenId` and `_toTokenId` do not match.
+  - MUST revert if `_value` exceeds the value of `_fromTokenId` or its allowance to the operator.
+  - MUST emit `TransferValue` event.
+
+- The `transferFrom(uint256 _fromTokenId, address _to, uint256 _value)` function, which transfers value from one token ID to an address, SHOULD follow the rule below:
+
+  - MUST create a new ERC3525 token with the same slot to receive the transferred value.
+  - MUST revert unless `msg.sender` is the owner of `_fromTokenId`, an authorized operator or an operator who has been approved the whole token or at least `_value` of it.
+  - MUST revert if `_fromTokenId` is zero token id or does not exist.
+  - MUST revert if `_to` is zero address.
+  - MUST revert if `_value` exceeds the value of `_fromTokenId` or its allowance to the operator.
+  - MUST emit `Transfer` and `TransferValue` events.
 
 **_safeTransferFrom rules:_**
 
-- `safeTransferFrom` SHOULD be used to implement the same function as `transferFrom`, with an extra step to check if the recipient is capable of receiving ERC-3525 token units by implementing the `onERC3525Received` interface.
-- MUST obey the above rules set for `transferFrom`.
-- MUST check if `_to` is a smart contract (code size > 0). If so, `safeTransferFrom` MUST call `onERC3525Received` on `_to` and MUST revert if the return value does not match `bytes4(keccak256("onERC3525Received(address,address,uint256,uint256,bytes)"))`
+- `safeTransferFrom` SHOULD be used to implement the same function as `transferFrom`, with an extra step to check if the recipient is capable of receiving ERC-3525 tokens by implementing the `onERC3525Received` interface.
+- MUST follow the above rules set for `transferFrom`.
+- MUST check if `_to` is a smart contract (code size > 0). If so, `safeTransferFrom` MUST call `onERC3525Received` on `_to` and MUST revert if the return value does not match `bytes4(keccak256("onERC3525Received(address,uint256,uint256,uint256,bytes)"))`
 
-
-
-
-### Metadata 
-
+### Metadata
 
 #### Metadata Extensions
 
@@ -340,11 +435,39 @@ ERC-3525 metadata extensions are compatible ERC-721 metadata extensions.
 The optional ERC3525Metadata extension can be identified with the ERC-165 Standard Interface Detection.
 
 ```solidity
+pragma solidity ^0.8.0;
 
-pragma solidity ^0.7.6;
-interface ERC3525Metadata /* is IERC721Metadata */ {
+/**
+ * @title ERC-3525 Semi-Fungible Token Standard, optional extension for metadata
+ * @dev Interfaces for any contract that wants to support query of the Uniform Resource Identifier
+ *  (URI) for the ERC3525 contract as well as a specified slot. 
+ *  Because of the higher reliability of data stored in smart contracts compared to data stored in 
+ *  centralized systems, it is recommended that metadata, including `contractURI`, `slotURI` and 
+ *  `tokenURI`, be directly returned in JSON format, instead of being returned with a url pointing 
+ *  to any resource stored in a centralized system. 
+ *  See https://eips.ethereum.org/EIPS/eip-3525
+ * Note: the ERC-165 identifier for this interface is 0xe1600902.
+ */
+interface IERC3525Metadata is
+    IERC3525 /* , IERC721Metadata */
+{
+    /**
+     * @notice Returns the Uniform Resource Identifier (URI) for the current ERC3525 contract.
+     * @dev This function SHOULD return the URI for this contract in JSON format, starting with
+     *  header `data:application/json;`.
+     *  See https://eips.ethereum.org/EIPS/eip-3525 for the JSON schema for contract URI.
+     * @return The JSON formatted URI of the current ERC3525 contract
+     */
     function contractURI() external view returns (string memory);
-    function slotURI(uint256 slot_) external view returns (string memory);
+
+    /**
+     * @notice Returns the Uniform Resource Identifier (URI) for the specified slot.
+     * @dev This function SHOULD return the URI for `_slot` in JSON format, starting with header
+     *  `data:application/json;`.
+     *  See https://eips.ethereum.org/EIPS/eip-3525 for the JSON schema for slot URI.
+     * @return The JSON formatted URI of `_slot`
+     */
+    function slotURI(uint256 _slot) external view returns (string memory);
 }
 ```
 
@@ -352,29 +475,28 @@ interface ERC3525Metadata /* is IERC721Metadata */ {
 
 This is the "ERC-3525 Metadata JSON Schema for contractURI()" referenced above.
 
-
 ```json
 {
-    "title": "Contract Metadata",
-    "type": "object",
+  "title": "Contract Metadata",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Contract Name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Describes the contract "
+    },
+    "valueDecimals": {
+      "type": "integer",
+      "description": "The number of decimal places that the balance should display - e.g. 18, means to divide the token value by 1000000000000000000 to get its user representation."
+    },
     "properties": {
-        "name": {
-            "type": "string",
-            "description": "Contract Name"
-        },
-        "description": {
-            "type": "string",
-            "description": "Describes the contract "
-        },
-         "unitDecimals": {
-            "type": "integer",
-            "description": "The number of decimal places that the units should display - e.g. 18, means to divide the token units by 1000000000000000000 to get its user representation."
-        },
-        "properties": {
-            "type": "object",
-            "description": "Arbitrary properties. Values may be strings, numbers, object or arrays."
-        }
+      "type": "object",
+      "description": "Arbitrary properties. Values may be strings, numbers, objects or arrays."
     }
+  }
 }
 ```
 
@@ -382,101 +504,96 @@ This is the "ERC-3525 Metadata JSON Schema for slotURI(uint)" referenced above.
 
 ```json
 {
-    "title": "Slot Metadata",
-    "type": "object",
+  "title": "Slot Metadata",
+  "type": "object",
+  "properties": {
     "properties": {
-         "tokensInSlot": {
-            "type": "integer",
-            "description": "Number of tokens in this slot, i.e., the number of tokens that have same business attributes represented by the slot."
-        },
-         "unitsInSlot": {
-            "type": "integer",
-            "description": "Total units in the slot, since tokens in same slot are fungible, this value equals to the sum of units of all tokens in this slot."
-        },
-        "properties": {
-            "type": "object",
-            "description": "Arbitrary properties. Values may be strings, numbers, object or arrays."
-        }
+      "type": "object",
+      "description": "Arbitrary properties. Values may be strings, numbers, objects or arrays."
     }
+  }
 }
 ```
+
 
 This is the "ERC-3525 Metadata JSON Schema for tokenURI(uint)" referenced above.
 
 ```json
 {
-    "title": "Token Metadata",
-    "type": "object",
+  "title": "Token Metadata",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Identifies the asset to which this NFT represents"
+    },
+    "description": {
+      "type": "string",
+      "description": "Describes the asset to which this NFT represents"
+    },
+    "image": {
+      "type": "string",
+      "description": "A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents."
+    },
+    "balance": {
+      "type": "BigNumber",
+      "description": ""
+    },
+    "slot": {
+      "type": "BigNumber",
+      "description": "The id of the slot that this token belongs to."
+    },
     "properties": {
-        "name": {
-            "type": "string",
-            "description": "Identifies the asset to which this NFT represents"
-        },
-        "description": {
-            "type": "string",
-            "description": "Describes the asset to which this NFT represents"
-        },
-        "image": {
-            "type": "string",
-            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents."
-        },
-         "units": {
-            "type": "BigNumber",
-            "description": ""
-        },
-	 "slot": {
-            "type": "BigNumber",
-            "description": "The id of the slot that this token belongs to."
-        },
-        "properties": {
-            "type": "object",
-            "description": "Arbitrary properties. Values may be strings, numbers, object or arrays."
-        }
+      "type": "object",
+      "description": "Arbitrary properties. Values may be strings, numbers, objects or arrays."
     }
+  }
 }
 ```
 
-### Approval
 
-ERC-3525 adds a new approval model, that is, one can approve operators to transfer units from a token with certain ID, the new interface is:
-```function approve(address to, uint256 tokenId, uint256 units); ```
-
-
-
-## Rationale 
+## Rationale
 
 ### Metadata generation
 
-Since ERC-3525 is designed for representing underlying assets, rather than artifacts for gaming or arts, the implementation should give out the metadata directly from contract code, rather than give a URL of a server for returning metadata.
+The ERC-3525 token standard is designed to represent semi-fungible assets, which are most suited for financial instruments rather than collectibles or in-game items. For maximum transparency and safety of digital assets, the implementation should generate metadata directly from contract code rather than giving out a server URL.
 
+### Design decision: Value transfer from token to address
+
+The 'value' of an ERC-3525 token is a property of the token and is not linked to an address, so to transfer the value to an address would be actually transferring it to a token owned by that address, not the address itself.
+
+From the implementation perspective, the process of transferring values from token to address could be done as follows: (1) create a new token for the recipient's address, (2) transfer the value to the new token from the 'source token'. So that this method is not fully independent from the ID-to-ID transfer method, and can be viewed as syntactic sugar that wraps the process described above.
+
+
+In a special case, if the destination address owns one or more tokens with the same slot value as the source token, this method will have an alternative implementation as follows: (1) find one token owned by the address with the same slot value of the source token, (2) transfer the value to the found token. Both implementation should be treated as compliant with this standard.
+
+The purpose of maintaining id-to-address transfer function is to maximize the compatibility with most wallet apps, since for most of the token standards, the destination of token transfer are addresses. This syntactic wrapping will help wallet apps easily implement the value transfer function from an ERC-3525 token to any address.
 
 ### Design decision: Keep unsafe transfer
 
 There are mainly two reasons we keep the unsafe transfer interfaces:
 
 1. Since ERC-3525 token is ERC-721 compatible, we must keep compatibility for all wallets and contracts that are still calling unsafe transfer interfaces for ERC-721 tokens.
-2. We want to keep the ability that dapps can trigger business logic on contracts by simply transferring ERC-3525 tokens to them, that is, a contract can put business logic in `onERC3525Received` function so that it can be called whenever a token is transferred using `safeTransferFrom`. However, in this situation, an approved contract with customized transfer functions like deposit etc. SHOULD never call `safeTransferFrom` since it will result in confusion that whether `onERC3525Received` is called by itself or other dapps that safe transfer a token to it.
+2. We want to keep the ability that dapps can trigger business logic on contracts by simply transferring ERC-3525 tokens to them, that is, a contract can put business logic in `onERC3525Received` function so that it can be called whenever a token is transferred using `safeTransferFrom`. However, in this situation, an approved contract with customized transfer functions like deposit etc. SHOULD never call `safeTransferFrom` since it will result in confusion that whether `onERC3525Received` is called by itself or other dapps that call the safeTransferFrom function.
 
 
-### Approval
+### Design decision: Relationship between different approval models
 
-For maximum semantical compatibility with ERC-721, as well as simplifying the approval model, we decided to make the relationship between two levels of approval like that:
+For semantic compatibility with ERC-721 as well as the flexibility of value manipulation of tokens, we decided to define the relationships between some of the levels of approval like that:
 
-1. Approval of an id does not result in the ability to partial transfer units from this id by the approved operator;
-2. Approval of all units in a token does not result in the ability to transfer the token entity by the approved operator;
-3. `setApprovalForAll` will result in the ability to transfer any tokens from the owner, as well as the ability to partial transfer units from any token.
-3. `setApprovalForAll` will result in the ability to approve any tokens of the owner to third parties, as well as the ability to approve partial transfer units of any token to third parties.
+1. Approval of an id will lead to the ability to partially transfer values from this id by the approved operator, this will simply the value approval for an id. However, the approval of total values in a token should not lead to the ability to transfer the token entity by the approved operator.
+2. setApprovalForAll will lead to the ability to partially transfer values from any token, as well as the ability to approve partial transfer of values from any token to a third party, this will simply the value transfer and approval of any tokens owned by an address.
 
 
 ## Backwards Compatibility
-	
-As mentioned at the very beginning, a ERC-3525 is an extension interface of ERC721, hence it is 100% compatible with ERC-721.
 
+As mentioned in the beginning, ERC-3525 is an extension interface of ERC-721, and therefore 100% compatible with the latter.
 
-## Reference Implementation
+## Implementations
 
-- [SOLV Vouchers - VNFT-core](https://github.com/solv-finance/solv-v2-voucher/tree/main/packages/solv-vnft-core/contracts)
-
+- [ERC-3525 implementation by SOLV Protocol](https://github.com/solv-finance/erc-3525)
 
 ## Copyright
-Copyright and related rights waived via [CC0](../LICENSE.md).
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+


### PR DESCRIPTION
* Create eip-vnft

* Create EIP-3525.md

* Delete eip-vnft

* Rename EIPS/EIP-3525.md to eip-3525.md

* Update and rename eip-3525.md to EIPs/eip-3525.md

* Delete EIPs directory

* Create eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Rename eip-3525.md to eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Complete contents for first time.

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* Update eip-vnft.md

* update EIP-VNFT

* Update eip-vnft.md

* Update eip-vnft.md

* Rename eip-vnft.md to eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Apply suggestions from code review

Co-authored-by: lightclient <14004106+lightclient@users.noreply.github.com>

* Update eip-3525.md

Refinement of summary, abstract and motivation sections, from both will wang and mike meng.

* Update eip-3525.md

* Update eip-3525.md

* Solv-vouchers implementation made open-source

also remove the the source as reference implementation, since it is not currently the suggested reference implementation yet.

* Update eip-3525.md

* correction on email

Co-authored-by: lightclient <14004106+lightclient@users.noreply.github.com>

* Remove the References section

* partially change VNFT to ERC3525/ERC-3525

* change decimals to unitDecimals

and other small fixes

* completely replace VNFT with ERC-3525

and some other small fixes

* Update eip-3525.md

add contractURI()

* Update eip-3525.md

add slotURI()

* completion of some descriptions

* Update eip-3525.md

fix typo

* Update eip-3525.md

* Update EIPS/eip-3525.md

Co-authored-by: Micah Zoltu <micah@zoltu.net>

* Update eip-3525.md

1. the slot's enumeration extension change to OPTIONAL 
2. add underlying asset container interface

* Update eip-3525.md

add SlotManagable interface

* Update eip-3525.md

1. add enumerable function for manager of slot
2. add interface for underlying asset

* 1. rename transferFrom with targetTokenId to transferUnitsFrom
2. add underlyingContainer interface

* add TODO

* refactor

* rename unit to value

* add payable

* Update eip-3525.md

update functions for interface

* Update eip-3525.md

update metadata interface

* Revise scenarios of ERC3525

* Revise of interface & functions

* Changing the description of the standard

* add new explanations to transfer models

* some corrections

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* revise some words and expressions

* Update eip-3525.md

Add more descriptions to the value transfer to address function

* replace appearances of 'units' by value

* Update eip-3525.md

* Update eip-3525.md

* Add table of contents

* Update eip-3525.md

* Update eip-3525.md

* completed Table of contents

* revise event name

* revert the name of slotChanged event

* Update eip-3525.md

* updated implementation url

* revise the approval models and their relationships

* revise transfer model

revise the description of id-to-address transfer model

* correct the discussion-to url

* Update eip-3525.md

* Update eip-3525.md

* Update eip-3525.md

* remove the references link

Co-authored-by: Ethan Y. Tsai <yee.tsai@gmail.com>
Co-authored-by: du <dujc2020@gmail.com>
Co-authored-by: lightclient <14004106+lightclient@users.noreply.github.com>
Co-authored-by: Micah Zoltu <micah@zoltu.net>

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
